### PR TITLE
Fix multiply [FromBody] parameters in PermissionQuery 

### DIFF
--- a/src/Hive.PermissionQuery/Models/QueryParams.cs
+++ b/src/Hive.PermissionQuery/Models/QueryParams.cs
@@ -1,0 +1,7 @@
+﻿using System.Collections.Generic;
+using Hive.Models;
+
+namespace Hive.PermissionQuery.Models
+{
+    public record QueryParams(IList<string> Actions, ModIdentifier? Mod, string? Channel);
+}


### PR DESCRIPTION
In ASP.NET Core, only one parameter in a REST action can be marked as `[FromBody]`, however in my original PermissionQuery PR, there were 3, which would cause the plugin to error at runtime.

This PR fixes the problem by wrapping the body parameters in a class.