### PR TITLE
Fix stupidity

### DIFF
--- a/src/Hive.Tags/Plugins/TagUploadPlugin.cs
+++ b/src/Hive.Tags/Plugins/TagUploadPlugin.cs
@@ -35,7 +35,7 @@ namespace Hive.Tags.Plugins
         {
             validationFailureInfo = null;
 
-            return false;
+            return true;
         }
     }
 }


### PR DESCRIPTION
Hive.Tags currently blocks every upload without attached tags because I stupidly set the default case to return `false` (upload is invalid) rather than `true` (upload is valid)