### PR TITLE
Refactor config to support absolute path

### DIFF
--- a/docs/Hive.FileSystemCdnProvider/Configuration.md
+++ b/docs/Hive.FileSystemCdnProvider/Configuration.md
@@ -8,7 +8,7 @@ This is a path (absolute or relative) where Hive will store uploaded mod files. 
 
 ## `CdnMetadataPath` - `string`
 
-This is path (absolute or relative) where Hive will store the metadata files for each uploaded file. By default, this is `cdn/metadata`.
+This is a path (absolute or relative) where Hive will store the metadata files for each uploaded file. By default, this is `cdn/metadata`.
 
 This is intentionally different from the Objects folder, so the maintainer can easily control access to the Objects folder and the Metadata folder.
 

--- a/docs/Hive.FileSystemCdnProvider/Configuration.md
+++ b/docs/Hive.FileSystemCdnProvider/Configuration.md
@@ -2,13 +2,13 @@
 
 The CDN Provider allows Hive to locally store uploaded mod files on the file system.
 
-## `CdnObjectsSubfolder` - `string`
+## `CdnObjectsPath` - `string`
 
-This is a relative path to a subfolder where Hive will store uploaded mod files. By default, this subfolder is `cdn/objects`.
+This is a path (absolute or relative) where Hive will store uploaded mod files. By default, this is `cdn/objects`.
 
-## `CdnMetadataSubfolder` - `string`
+## `CdnMetadataPath` - `string`
 
-This is a relative path to a subfolder where Hive will store the metadata files for each uploaded file. By default, this subfolder is `cdn/metadata`.
+This is path (absolute or relative) where Hive will store the metadata files for each uploaded file. By default, this is `cdn/metadata`.
 
 This is intentionally different from the Objects folder, so the maintainer can easily control access to the Objects folder and the Metadata folder.
 

--- a/docs/Hive.FileSystemRuleProvider/Configuration.md
+++ b/docs/Hive.FileSystemRuleProvider/Configuration.md
@@ -4,9 +4,9 @@ A key component to Hive is its permission system, and the rules that govern it.
 
 This page is for the configuration of Hive's permission system. [Please visit this link for documentation on the permission system itself.](https://github.com/Atlas-Rhythm/Hive/blob/master/Hive.Permissions/docs/Usage.md).
 
-## `RuleSubfolder` - `string`
+## `RulePath` - `string`
 
-This determines the subfolder in the Hive installation folder where permission rules will be read from. By default, this is set to a `Rules` subfolder.
+This determines the path (absolute or relative) where permission rules will be read from. By default, this is set to `Rules`.
 
 # File System Structure
 

--- a/src/Hive.FileSystemCdnProvider/FileSystemCdnOptions.cs
+++ b/src/Hive.FileSystemCdnProvider/FileSystemCdnOptions.cs
@@ -4,8 +4,8 @@ namespace Hive.FileSystemCdnProvider
 {
     public class FileSystemCdnOptions
     {
-        public string CdnObjectsSubfolder { get; private set; } = "cdn/objects";
-        public string CdnMetadataSubfolder { get; private set; } = "cdn/metadata";
+        public string CdnObjectsPath { get; private set; } = "cdn/objects";
+        public string CdnMetadataPath { get; private set; } = "cdn/metadata";
         public Uri? PublicUrlBase { get; private set; }
     }
 }

--- a/src/Hive.FileSystemCdnProvider/FileSystemCdnProvider.cs
+++ b/src/Hive.FileSystemCdnProvider/FileSystemCdnProvider.cs
@@ -16,10 +16,7 @@ namespace Hive.FileSystemCdnProvider
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly string? publicUrlBase;
 
-        private readonly string cdnObjectSubfolder;
         private readonly string cdnObjectPath;
-
-        private readonly string cdnMetadataSubfolder;
         private readonly string cdnMetadataPath;
 
         public FileSystemCdnProvider(ILogger logger, IHttpContextAccessor httpContextAccessor, IOptions<FileSystemCdnOptions> options)
@@ -32,13 +29,10 @@ namespace Hive.FileSystemCdnProvider
             this.logger = logger;
             this.httpContextAccessor = httpContextAccessor;
 
-            cdnObjectSubfolder = options.Value.CdnObjectsSubfolder;
-            cdnMetadataSubfolder = options.Value.CdnMetadataSubfolder;
-
             publicUrlBase = options.Value.PublicUrlBase?.ToString();
 
-            cdnObjectPath = Path.Combine(Directory.GetCurrentDirectory(), cdnObjectSubfolder);
-            cdnMetadataPath = Path.Combine(Directory.GetCurrentDirectory(), cdnMetadataSubfolder);
+            cdnObjectPath = Path.GetFullPath(options.Value.CdnObjectsPath);
+            cdnMetadataPath = Path.GetFullPath(options.Value.CdnMetadataPath);
 
             _ = Directory.CreateDirectory(cdnObjectPath);
             _ = Directory.CreateDirectory(cdnMetadataPath);

--- a/src/Hive.FileSystemRuleProvider/FileSystemRuleProvider.cs
+++ b/src/Hive.FileSystemRuleProvider/FileSystemRuleProvider.cs
@@ -26,19 +26,19 @@ namespace Hive.FileSystemRuleProvider
         /// Construct a rule provider via DI.
         /// </summary>
         /// <param name="logger">Logger provided with DI.</param>
-        /// <param name="ruleSubfolder">If not empty, the rule provider will treat this as the root rule directory.</param>
+        /// <param name="rulePath">If not empty, the rule provider will treat this as the root rule directory.</param>
         /// <param name="splitToken">The token used to split rules.</param>
         /// <remarks>
         /// The <paramref name="splitToken"/> parameter, and the one given to <see cref="PermissionsManager{TContext}"/>, should always be the same.
         /// </remarks>
-        public FileSystemRuleProvider(ILogger logger, StringView splitToken, string ruleSubfolder)
+        public FileSystemRuleProvider(ILogger logger, StringView splitToken, string rulePath)
         {
             this.logger = logger;
             this.splitToken = splitToken;
 
-            ruleDirectory = Path.Combine(Directory.GetCurrentDirectory(), ruleSubfolder);
+            ruleDirectory = Path.GetFullPath(rulePath);
 
-            _ = Directory.CreateDirectory(ruleSubfolder);
+            _ = Directory.CreateDirectory(ruleDirectory);
         }
 
         /// <inheritdoc/>

--- a/src/Hive.FileSystemRuleProvider/Startup.cs
+++ b/src/Hive.FileSystemRuleProvider/Startup.cs
@@ -10,8 +10,8 @@ namespace Hive.FileSystemRuleProvider
     public class Startup
     {
         private const string SplitToken = ".";
-        private const string SubfolderConfigurationKey = "RuleSubfolder";
-        private const string SubfolderDefaultValue = "Rules";
+        private const string PathConfigurationKey = "RulePath";
+        private const string PathDefaultValue = "Rules";
 
         public IConfiguration Configuration { get; }
 
@@ -20,10 +20,10 @@ namespace Hive.FileSystemRuleProvider
 
         public void ConfigureServices(IServiceCollection services)
         {
-            var subfolder = Configuration.GetValue(SubfolderConfigurationKey, SubfolderDefaultValue);
+            var path = Configuration.GetValue(PathConfigurationKey, PathDefaultValue);
 
             _ = services.AddTransient<IRuleProvider>(sp =>
-                    new FileSystemRuleProvider(sp.GetRequiredService<ILogger>(), SplitToken, subfolder));
+                    new FileSystemRuleProvider(sp.GetRequiredService<ILogger>(), SplitToken, path));
         }
     }
 }


### PR DESCRIPTION
This PR refactors the configuration in `Hive.FileSystemRuleProvider` to allow absolute paths in the configuration key.

Because we still have no production instances of Hive, I made a breaking change by changing the configuration key to better match the new behavior