### PR TITLE
Made Categories Plugin

### DIFF
--- a/HiveCorePlugins.sln
+++ b/HiveCorePlugins.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hive.Webhooks", "src\Hive.W
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hive.AdditionalUserDataExposer", "src\Hive.AdditionalUserDataExposer\Hive.AdditionalUserDataExposer.csproj", "{4CB8645F-0901-4D86-BAAD-D0E5E9ED6E64}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hive.Tags.Categories", "src\Hive.Tags.Categories\Hive.Tags.Categories.csproj", "{11DF3A46-C69A-4090-A0A6-CE2FAFF4FF08}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +80,10 @@ Global
 		{4CB8645F-0901-4D86-BAAD-D0E5E9ED6E64}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CB8645F-0901-4D86-BAAD-D0E5E9ED6E64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4CB8645F-0901-4D86-BAAD-D0E5E9ED6E64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11DF3A46-C69A-4090-A0A6-CE2FAFF4FF08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11DF3A46-C69A-4090-A0A6-CE2FAFF4FF08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11DF3A46-C69A-4090-A0A6-CE2FAFF4FF08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11DF3A46-C69A-4090-A0A6-CE2FAFF4FF08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/Hive.Tags.Categories/Configuration.md
+++ b/docs/Hive.Tags.Categories/Configuration.md
@@ -1,0 +1,33 @@
+# Configuration
+
+Hive.Tags.Categories uses Hive.Tags to provide category support for uploaded mods.
+
+A list of valid categories for a mod are provided in configuration. Upon upload, if a tag in the `additionalData:Tags`
+array of a mod contains a string element that starts with `category: `, it will be treated as such. It is up to
+front-ends to respect the prefix. If something is prefixed with `category: ` and is not in the valid categories list
+defined in the plugin configuration, the upload will be rejected.
+
+## Example
+
+```jsonc
+"Hive.Tags.Categories": {
+    "Categories": [
+        "Core",
+        "Libraries",
+        "Tools / Tweaks"
+    ]
+}
+```
+
+
+```jsonc
+// Snippet of an upload body
+{
+    // ...
+    "additionalData": {
+        "Tags": [
+            "category: Libraries"
+        ]
+    }
+}
+```

--- a/src/Hive.Tags.Categories/CategoryOptions.cs
+++ b/src/Hive.Tags.Categories/CategoryOptions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Hive.Tags.Categories;
+
+#pragma warning disable CA1819
+public class CategoryOptions
+{
+    public string[] Categories { get; init; } = Array.Empty<string>();
+}

--- a/src/Hive.Tags.Categories/CategoryTagController.cs
+++ b/src/Hive.Tags.Categories/CategoryTagController.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Hive.Tags.Categories;
+
+[ApiController]
+[Route("api/categories/")]
+public class CategoryTagController : ControllerBase
+{
+    private readonly CategoryOptions _categoryOptions;
+
+    public CategoryTagController(CategoryOptions categoryOptions) => _categoryOptions = categoryOptions;
+
+    [HttpGet]
+    public ActionResult<IEnumerable<string>> GetValidCategories() => Ok(_categoryOptions.Categories);
+}

--- a/src/Hive.Tags.Categories/CategoryTagPlugin.cs
+++ b/src/Hive.Tags.Categories/CategoryTagPlugin.cs
@@ -21,7 +21,7 @@ public class CategoryTagPlugin : ITagPlugin
             .Select(t => t[CategoryPrefix.Length..]);
 
         // If any of the provided tags are not in the category list, it's a fail.
-        if (currentTags.Any(t => _categoryOptions.Categories.Contains(t)))
+        if (!currentTags.Any(t => _categoryOptions.Categories.Contains(t)))
         {
             validationFailureInfo = "Unrecognized category tags";
             return false;

--- a/src/Hive.Tags.Categories/CategoryTagPlugin.cs
+++ b/src/Hive.Tags.Categories/CategoryTagPlugin.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hive.Plugins.Aggregates;
+using Hive.Tags.Plugins;
+
+namespace Hive.Tags.Categories;
+
+public class CategoryTagPlugin : ITagPlugin
+{
+    private readonly CategoryOptions _categoryOptions;
+    private const string CategoryPrefix = "category: ";
+
+    public CategoryTagPlugin(CategoryOptions categoryOptions) => _categoryOptions = categoryOptions;
+
+    [return: StopIfReturns(false)]
+    public bool AreTagsValid(IList<string> mutableTags, [ReturnLast] out object? validationFailureInfo)
+    {
+        var currentTags = mutableTags
+            .Where(t => t.StartsWith(CategoryPrefix, StringComparison.InvariantCulture))
+            .Select(t => t[CategoryPrefix.Length..]);
+
+        // If any of the provided tags are not in the category list, it's a fail.
+        if (currentTags.Any(t => _categoryOptions.Categories.Contains(t)))
+        {
+            validationFailureInfo = "Unrecognized category tags";
+            return false;
+        }
+
+        validationFailureInfo = null;
+        return true;
+    }
+}

--- a/src/Hive.Tags.Categories/Hive.Tags.Categories.csproj
+++ b/src/Hive.Tags.Categories/Hive.Tags.Categories.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Sdk Name="Hive.Plugin.Sdk" Version="0.1.0-gh890.1" />
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Hive.Tags\Hive.Tags.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Hive.Tags.Categories/Startup.cs
+++ b/src/Hive.Tags.Categories/Startup.cs
@@ -1,0 +1,24 @@
+﻿using DryIoc;
+using Hive.Plugins;
+using Hive.Tags.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Hive.Tags.Categories;
+
+[PluginStartup]
+public class Startup
+{
+    private readonly IConfiguration _configuration;
+
+    public Startup(IConfiguration config) => _configuration = config;
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        _ = services.Configure<CategoryOptions>(_configuration);
+        _ = services.AddSingleton(sp => sp.GetRequiredService<IOptions<CategoryOptions>>().Value);
+    }
+
+    public static void ConfigureContainer(Container container) => container.Register<ITagPlugin, CategoryTagPlugin>();
+}


### PR DESCRIPTION
This plugin introduces a new endpoint and validation feature for tags prefixed with `category: `.

Learn more in the Configuration.md file